### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project Overview
+
+botgroup.chat is an AI multi-player group chat platform built with React 18 + Vite (frontend) and Cloudflare Pages Functions (backend/serverless). It uses Cloudflare D1 (SQLite) as the database and KV for OAuth state.
+
+### Quick Reference
+
+- **Package manager**: npm (lockfile: `package-lock.json`)
+- **Dev server**: `npx wrangler pages dev -- npm run dev` (serves at `http://localhost:8788`)
+- **Build**: `npm run build` (output in `dist/`)
+- **Frontend only**: `npm run dev` (Vite on port 3000, no backend)
+- **DB migrations**: `npx wrangler d1 migrations apply friends --local`
+
+### Dev Environment Setup Notes
+
+1. **wrangler is a local devDependency** — always use `npx wrangler` instead of bare `wrangler`. The `init-db.sh` and `devrun.sh` scripts use bare `wrangler` and will fail unless you adjust them.
+
+2. **Database init**: Run `npx wrangler d1 migrations apply friends --local` to create/update the local D1 database. The old `init-db.sh` script uses deprecated wrangler v3 flags (`--local`, `--persist-to`) that no longer work in wrangler v4+.
+
+3. **Environment variables**: Create a `.dev.vars` file in the project root with at least:
+   ```
+   JWT_SECRET=<any-string-for-local-dev>
+   ```
+   Optionally add LLM API keys (`DEEPSEEK_API_KEY`, `DASHSCOPE_API_KEY`, etc.) for AI responses to work.
+
+4. **Auth bypass for dev**: The app uses `AUTH_ACCESS` in `public/config.js` (default `"1"` = login required). To access the chat UI without OAuth, generate a JWT token signed with your `JWT_SECRET` and set it in `localStorage('token')`. The JWT payload needs a `userId` field.
+
+5. **No ESLint or test scripts**: The project does not have ESLint configuration or test scripts defined in `package.json`. There is a `playwright` devDependency but no test files or config.
+
+6. **TypeScript**: The project uses TypeScript but has no `tsc --noEmit` check script. Vite build (`npm run build`) performs type-free bundling — it will catch import/syntax errors but not type errors.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment setup instructions for Cursor Cloud agents.

### What's included

- Project overview (React + Vite frontend, Cloudflare Pages Functions backend)
- Quick reference commands for dev server, build, and DB migrations
- Important dev environment notes:
  - `wrangler` must be invoked via `npx` (local devDependency)
  - DB migration command for wrangler v4+
  - `.dev.vars` configuration for JWT_SECRET and LLM API keys
  - Auth bypass instructions for local development
  - Notes about missing lint/test tooling

### Dev environment verification

The development environment was fully set up and verified:

[botgroup_chat_demo.mp4](https://cursor.com/agents/bc-f8fdbfc8-4b60-44c1-99a1-cfc464bd91ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbotgroup_chat_demo.mp4)

[Chat interface with groups loaded](https://cursor.com/agents/bc-f8fdbfc8-4b60-44c1-99a1-cfc464bd91ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_groups_loaded.webp)
[Message successfully sent in chat](https://cursor.com/agents/bc-f8fdbfc8-4b60-44c1-99a1-cfc464bd91ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmessage_sent.webp)

- `npm install` — dependencies installed successfully
- `npm run build` — Vite build succeeds (1653 modules)
- `npx wrangler d1 migrations apply friends --local` — all 17 migrations applied
- `npx wrangler pages dev -- npm run dev` — dev server runs at localhost:8788
- Frontend loads, auth works with JWT token, message sending works


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8fdbfc8-4b60-44c1-99a1-cfc464bd91ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8fdbfc8-4b60-44c1-99a1-cfc464bd91ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

