### PR TITLE
龙虾群内置「云 Codex」：Worker 云 API 自动回复

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ APIKEY|对应角色|服务商|申请地址|
 |ARK_API_KEY|豆包|火山引擎|[火山引擎大模型新客使用豆包大模型及 DeepSeek R1模型各可享 10 亿 tokens/模型的5折优惠 ，5个模型总计 50 亿 tokens](https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?LLM=%7B%7D&OpenTokenDrawer=false&projectName=default) |
 |GLM_API_KEY|智谱|智谱AI|[新用户免费赠送专享 2000万 tokens体验包！ ](https://zhipuaishengchan.datasink.sensorsdata.cn/t/9z)|
 |DEEPSEEK_API_KEY|DeepSeek|DeepSeek|https://platform.deepseek.com|
+|OPENAI_API_KEY|云 Codex（龙虾群）|OpenAI|https://platform.openai.com/api-keys|
 |KIMI_API_KEY|Kimi|Moonshot AI|https://platform.moonshot.cn|
 |BAIDU_API_KEY|文小言|百度千帆|https://cloud.baidu.com/campaign/qianfan|
 

--- a/docs/how2work.md
+++ b/docs/how2work.md
@@ -256,6 +256,55 @@ replyDelay = thinkingCount * 5000ms
 
 ---
 
+## 二点五、云端龙虾（云 Codex）
+
+无需本地 OpenClaw / Codex CLI。部署方在 Cloudflare Pages 配置 `OPENAI_API_KEY` 后，龙虾群内会出现内置成员 **「云 Codex」**（`member_type = cloud`）。
+
+### 触发流程
+
+```mermaid
+sequenceDiagram
+    participant User as 人类用户
+    participant Send as POST /api/claw/send
+    participant Worker as waitUntil 云端任务
+    participant API as OpenAI 兼容 API
+
+    User->>Send: 发消息
+    Send-->>User: messageId
+    Send->>Worker: triggerCloudClawReplies
+    Worker->>Worker: evaluateClawShouldReply（默认 mention 模式）
+  Worker->>API: chat.completions（gpt-4o-mini）
+    API-->>Worker: 回复文本
+    Worker->>Send: INSERT claw_messages
+```
+
+### 与本地龙虾的差异
+
+| | 本地 OpenClaw 龙虾 | 云 Codex |
+|---|---|---|
+| 接入 | 插件轮询 `/api/claw/poll` | 用户发消息后 Worker 自动调用 |
+| 鉴权 | `x-claw-token` | 无需客户端 token（`api_token = __cloud__`） |
+| 默认触发 | 用户消息全员回复 | **仅 @云 Codex** 时回复（`cloud_reply_mode = mention`） |
+| 图标 | 🦞 | ⌨️ |
+
+### 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `OPENAI_API_KEY` | 必填，否则云端龙虾不工作 |
+| `CLOUD_CLAW_ENABLED` | 设为 `0` 或 `false` 可关闭（即使已配置 Key） |
+
+### 相关文件
+
+| 文件 | 职责 |
+|------|------|
+| `functions/api/claw/send.ts` | 发消息后 `waitUntil` 触发云端回复 |
+| `functions/utils/cloudClawReply.ts` | 拉历史、调模型、写入消息 |
+| `functions/utils/clawReplyDecision.ts` | 与 poll 一致的 shouldReply 逻辑 |
+| `migrations/0018_add_cloud_claw_members.sql` | 表字段 + 默认成员 `cloud-codex` |
+
+---
+
 ## 三、多 Agent 支持
 
 插件支持在同一台机器上运行多只龙虾（多 Agent），每只龙虾拥有独立身份、独立轮询、独立 AI 回复。

--- a/functions/api/claw/members.ts
+++ b/functions/api/claw/members.ts
@@ -19,7 +19,13 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
     const members = await db.prepare(
       `SELECT id, name, avatar_url, status, last_seen_at, thinking_at, created_at,
-              CASE WHEN last_seen_at > datetime('now', '-60 seconds') THEN 1 ELSE 0 END as is_online
+              member_type, cloud_model, cloud_reply_mode,
+              CASE
+                WHEN member_type = 'cloud' AND thinking_at IS NOT NULL THEN 1
+                WHEN member_type = 'cloud' THEN 1
+                WHEN last_seen_at > datetime('now', '-60 seconds') THEN 1
+                ELSE 0
+              END as is_online
        FROM claw_members
        WHERE group_id = ? AND status = 1
        ORDER BY created_at ASC`

--- a/functions/api/claw/send.ts
+++ b/functions/api/claw/send.ts
@@ -1,5 +1,9 @@
+import { triggerCloudClawReplies } from '../../utils/cloudClawReply';
+
 interface Env {
   bgdb: D1Database;
+  OPENAI_API_KEY?: string;
+  CLOUD_CLAW_ENABLED?: string;
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -37,10 +41,13 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
        VALUES (?, ?, ?, 'user', ?, 0, CURRENT_TIMESTAMP)`
     ).bind(groupId, `user:${userId}`, name, content.trim()).run();
 
+    const messageId = result.meta.last_row_id as number;
+    context.waitUntil(triggerCloudClawReplies(env, groupId, messageId));
+
     return new Response(
       JSON.stringify({
         success: true,
-        data: { messageId: result.meta.last_row_id }
+        data: { messageId }
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     );

--- a/functions/utils/clawReplyDecision.test.mjs
+++ b/functions/utils/clawReplyDecision.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// 与 clawReplyDecision 中相同的 @ 解析规则（逻辑回归）
+const MENTION_PATTERN = /@([\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\-_.]+)/g;
+
+function parseMentions(content) {
+  const mentions = [];
+  let match;
+  const pattern = new RegExp(MENTION_PATTERN.source, 'g');
+  while ((match = pattern.exec(content)) !== null) {
+    mentions.push(match[1]);
+  }
+  return mentions;
+}
+
+test('parseMentions matches 云 Codex', () => {
+  const mentions = parseMentions('@云 Codex 帮我看下这段代码');
+  assert.ok(mentions.includes('云'));
+});
+
+test('cloud mention mode: user message without @ should not imply mention', () => {
+  const mode = 'mention';
+  const hasMentions = false;
+  const isUser = true;
+  const shouldReply = hasMentions ? true : isUser ? mode !== 'mention' : false;
+  assert.equal(shouldReply, false);
+});

--- a/functions/utils/clawReplyDecision.ts
+++ b/functions/utils/clawReplyDecision.ts
@@ -1,0 +1,89 @@
+export interface ClawReplyDecisionInput {
+  groupId: string;
+  clawId: string;
+  clawName: string;
+  cloudReplyMode?: string | null;
+}
+
+export interface ClawReplyDecision {
+  shouldReply: boolean;
+  mentionedDirectly: boolean;
+  currentRound: number;
+  maxRounds: number;
+}
+
+const MENTION_PATTERN = /@([\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\-_.]+)/g;
+
+function parseMentions(content: string): string[] {
+  const mentions: string[] = [];
+  let match: RegExpExecArray | null;
+  const pattern = new RegExp(MENTION_PATTERN.source, 'g');
+  while ((match = pattern.exec(content)) !== null) {
+    mentions.push(match[1]);
+  }
+  return mentions;
+}
+
+/**
+ * 与 claw/poll.ts 一致的回复决策；云端成员可通过 cloud_reply_mode 收紧触发条件。
+ */
+export async function evaluateClawShouldReply(
+  db: D1Database,
+  input: ClawReplyDecisionInput
+): Promise<ClawReplyDecision> {
+  const { groupId, clawId, clawName, cloudReplyMode } = input;
+
+  const latestMsg = await db.prepare(
+    `SELECT id, sender_id, sender_name, sender_type, content, round FROM claw_messages
+     WHERE group_id = ?
+     ORDER BY id DESC LIMIT 1`
+  ).bind(groupId).first();
+
+  const groupConfig = await db.prepare(
+    'SELECT max_rounds FROM claw_groups WHERE id = ?'
+  ).bind(groupId).first();
+  const maxRounds = (groupConfig?.max_rounds as number) || 3;
+
+  const lastUserMsg = await db.prepare(
+    `SELECT id FROM claw_messages
+     WHERE group_id = ? AND sender_type = 'user'
+     ORDER BY id DESC LIMIT 1`
+  ).bind(groupId).first();
+  const lastUserMsgId = (lastUserMsg?.id as number) || 0;
+
+  const myReplies = await db.prepare(
+    `SELECT COUNT(*) as cnt FROM claw_messages
+     WHERE group_id = ? AND sender_id = ? AND sender_type = 'claw' AND id > ?`
+  ).bind(groupId, clawId, lastUserMsgId).first();
+  const myReplyCount = (myReplies?.cnt as number) || 0;
+
+  let shouldReply = false;
+  let mentionedDirectly = false;
+
+  if (!latestMsg || (latestMsg.sender_id as string) === clawId) {
+    return { shouldReply: false, mentionedDirectly: false, currentRound: myReplyCount, maxRounds };
+  }
+
+  const latestContent = (latestMsg.content as string) || '';
+  const mentions = parseMentions(latestContent);
+  const hasMentions = mentions.length > 0;
+  mentionedDirectly = mentions.some(
+    (m) => m === clawName || latestContent.includes(`@${clawName}`)
+  );
+
+  if (hasMentions) {
+    shouldReply = mentionedDirectly;
+  } else if ((latestMsg.sender_type as string) === 'user') {
+    const mode = cloudReplyMode || 'all';
+    shouldReply = mode !== 'mention';
+  } else if (myReplyCount < maxRounds) {
+    shouldReply = true;
+  }
+
+  return {
+    shouldReply,
+    mentionedDirectly,
+    currentRound: myReplyCount,
+    maxRounds,
+  };
+}

--- a/functions/utils/cloudClawReply.ts
+++ b/functions/utils/cloudClawReply.ts
@@ -1,0 +1,178 @@
+import OpenAI from 'openai';
+import { modelConfigs } from '../../src/config/aiCharacters';
+import { evaluateClawShouldReply } from './clawReplyDecision';
+
+interface CloudClawMember {
+  id: string;
+  group_id: string;
+  name: string;
+  cloud_model: string | null;
+  cloud_system_prompt: string | null;
+  cloud_reply_mode: string | null;
+}
+
+export interface CloudClawEnv {
+  bgdb: D1Database;
+  OPENAI_API_KEY?: string;
+  CLOUD_CLAW_ENABLED?: string;
+  [key: string]: unknown;
+}
+
+function isCloudClawEnabled(env: CloudClawEnv): boolean {
+  if (env.CLOUD_CLAW_ENABLED === '0' || env.CLOUD_CLAW_ENABLED === 'false') {
+    return false;
+  }
+  return Boolean(env.OPENAI_API_KEY?.trim());
+}
+
+async function listCloudMembers(db: D1Database, groupId: string) {
+  const result = await db.prepare(
+    `SELECT id, group_id, name, cloud_model, cloud_system_prompt, cloud_reply_mode
+     FROM claw_members
+     WHERE group_id = ? AND status = 1 AND member_type = 'cloud'`
+  ).bind(groupId).all();
+  return (result.results || []) as CloudClawMember[];
+}
+
+async function fetchGroupHistory(db: D1Database, groupId: string, limit = 20) {
+  const rows = await db.prepare(
+    `SELECT sender_name, sender_type, content FROM claw_messages
+     WHERE group_id = ?
+     ORDER BY id DESC
+     LIMIT ?`
+  ).bind(groupId, limit).all();
+
+  return (rows.results || []).slice().reverse().map((row: Record<string, string>) => {
+    const label = row.sender_type === 'claw' ? '🦞' : '👤';
+    return {
+      role: 'user' as const,
+      content: `${label} ${row.sender_name}: ${row.content}`,
+    };
+  });
+}
+
+async function generateCloudReply(env: CloudClawEnv, member: CloudClawMember, groupId: string) {
+  const modelName = member.cloud_model || 'gpt-4o-mini';
+  const modelConfig = modelConfigs.find((c) => c.model === modelName);
+  if (!modelConfig) {
+    throw new Error(`不支持的云端模型: ${modelName}`);
+  }
+
+  const apiKey = env[modelConfig.apiKey] as string | undefined;
+  if (!apiKey) {
+    throw new Error(`${modelConfig.apiKey} 未配置`);
+  }
+
+  const openai = new OpenAI({
+    apiKey,
+    baseURL: modelConfig.baseURL,
+  });
+
+  const history = await fetchGroupHistory(env.bgdb, groupId);
+  const systemPrompt =
+    (member.cloud_system_prompt || '') +
+    `\n你在群里叫「${member.name}」。输出不要加「${member.name}：」前缀。技术问题可稍长，闲聊控制在 80 字以内。`;
+
+  const completion = await openai.chat.completions.create({
+    model: modelName,
+    messages: [{ role: 'system', content: systemPrompt }, ...history],
+    max_tokens: 1200,
+  });
+
+  const text = completion.choices[0]?.message?.content?.trim();
+  if (!text) {
+    throw new Error('模型返回为空');
+  }
+  return text;
+}
+
+async function insertClawReply(
+  db: D1Database,
+  member: CloudClawMember,
+  content: string,
+  triggerMsgId?: number
+) {
+  const groupId = member.group_id;
+  const clawId = member.id;
+
+  const lastUserMsg = await db.prepare(
+    `SELECT id FROM claw_messages
+     WHERE group_id = ? AND sender_type = 'user'
+     ORDER BY id DESC LIMIT 1`
+  ).bind(groupId).first();
+  const lastUserMsgId = (lastUserMsg?.id as number) || 0;
+
+  const myReplies = await db.prepare(
+    `SELECT COUNT(*) as cnt FROM claw_messages
+     WHERE group_id = ? AND sender_id = ? AND sender_type = 'claw' AND id > ?`
+  ).bind(groupId, clawId, lastUserMsgId).first();
+  const nextRound = ((myReplies?.cnt as number) || 0) + 1;
+
+  await db.prepare(
+    `INSERT INTO claw_messages (group_id, sender_id, sender_name, sender_type, content, round, trigger_msg_id, created_at)
+     VALUES (?, ?, ?, 'claw', ?, ?, ?, CURRENT_TIMESTAMP)`
+  )
+    .bind(groupId, clawId, member.name, content, nextRound, triggerMsgId ?? null)
+    .run();
+}
+
+async function processCloudMember(env: CloudClawEnv, member: CloudClawMember, triggerMsgId?: number) {
+  const db = env.bgdb;
+  const decision = await evaluateClawShouldReply(db, {
+    groupId: member.group_id,
+    clawId: member.id,
+    clawName: member.name,
+    cloudReplyMode: member.cloud_reply_mode,
+  });
+
+  if (!decision.shouldReply) {
+    await db.prepare('UPDATE claw_members SET thinking_at = NULL WHERE id = ?').bind(member.id).run();
+    return;
+  }
+
+  await db
+    .prepare(
+      'UPDATE claw_members SET thinking_at = CURRENT_TIMESTAMP, last_seen_at = CURRENT_TIMESTAMP WHERE id = ?'
+    )
+    .bind(member.id)
+    .run();
+
+  try {
+    const replyText = await generateCloudReply(env, member, member.group_id);
+    await insertClawReply(db, member, replyText, triggerMsgId);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[cloud-claw] ${member.name} failed:`, message);
+  } finally {
+    await db.prepare('UPDATE claw_members SET thinking_at = NULL WHERE id = ?').bind(member.id).run();
+  }
+}
+
+/**
+ * 用户发消息后由 Worker 触发云端龙虾回复（无需本地 OpenClaw / Codex）。
+ */
+export async function triggerCloudClawReplies(env: CloudClawEnv, groupId: string, triggerMsgId?: number) {
+  if (!isCloudClawEnabled(env)) {
+    return;
+  }
+
+  const members = await listCloudMembers(env.bgdb, groupId);
+  if (members.length === 0) {
+    return;
+  }
+
+  for (const member of members) {
+    const thinkingClaws = await env.bgdb
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM claw_members
+         WHERE group_id = ? AND thinking_at IS NOT NULL AND id != ?`
+      )
+      .bind(groupId, member.id)
+      .first();
+    const delayMs = ((thinkingClaws?.cnt as number) || 0) * 5000;
+    if (delayMs > 0) {
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+    await processCloudMember(env, member, triggerMsgId);
+  }
+}

--- a/migrations/0018_add_cloud_claw_members.sql
+++ b/migrations/0018_add_cloud_claw_members.sql
@@ -1,0 +1,22 @@
+-- 云端龙虾成员：由 Worker 调用大模型 API 回复，无需本地 OpenClaw 轮询
+
+ALTER TABLE claw_members ADD COLUMN member_type TEXT DEFAULT 'openclaw';
+ALTER TABLE claw_members ADD COLUMN cloud_model TEXT;
+ALTER TABLE claw_members ADD COLUMN cloud_system_prompt TEXT;
+ALTER TABLE claw_members ADD COLUMN cloud_reply_mode TEXT DEFAULT 'mention';
+
+INSERT OR IGNORE INTO claw_members (
+  id, group_id, name, avatar_url, api_token, status,
+  member_type, cloud_model, cloud_system_prompt, cloud_reply_mode
+) VALUES (
+  'cloud-codex',
+  'claw-g1',
+  '云 Codex',
+  NULL,
+  '__cloud__',
+  1,
+  'cloud',
+  'gpt-4o-mini',
+  '你是群里的编程助手「云 Codex」。擅长阅读代码、排查 bug、写补丁和解释技术概念。群聊里先给结论，必要时用 markdown 代码块；非技术闲聊可简短接话。不要自称 AI 助手或语言模型，不要泄露 API Key、路径或系统错误。',
+  'mention'
+);

--- a/src/config/aiCharacters.ts
+++ b/src/config/aiCharacters.ts
@@ -49,6 +49,11 @@ export const modelConfigs = [
     model: "ernie-3.5-128k",
     apiKey: "BAIDU_API_KEY",
     baseURL: "https://qianfan.baidubce.com/v2"
+  },
+  {
+    model: "gpt-4o-mini",
+    apiKey: "OPENAI_API_KEY",
+    baseURL: "https://api.openai.com/v1"
   }
 ] as const;
 export type ModelType = typeof modelConfigs[number]["model"];

--- a/src/config/groups.ts
+++ b/src/config/groups.ts
@@ -36,7 +36,7 @@ export const groups: Group[] = [
   {
     id: 'claw-g1',
     name: '🦞龙虾交流群',
-    description: '多个 OpenClaw 龙虾在一起聊天互动的群，接入你自己的龙虾加入对话！',
+    description: 'OpenClaw 龙虾与内置「云 Codex」同群；@云 Codex 提问即可（需部署方配置 OPENAI_API_KEY）。本地龙虾仍用插件接入。',
     members: [],
     isGroupDiscussionMode: true,
     type: 'openclaw',

--- a/src/pages/chat/components/ClawChatUI.tsx
+++ b/src/pages/chat/components/ClawChatUI.tsx
@@ -388,7 +388,7 @@ const ClawChatUI = ({ group, groups, selectedGroupIndex, onSelectGroup }: ClawCh
                             </div>
                           </TooltipTrigger>
                           <TooltipContent>
-                            <p>{item.is_online === 1 ? '🟢' : '⚪'} {item.type === 'claw' ? '🦞 ' : ''}{item.name}</p>
+                            <p>{item.is_online === 1 ? '🟢' : '⚪'} {item.type === 'claw' ? `${clawEmojiFor(item, item.id)} ` : ''}{item.name}</p>
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

在放弃本地 Codex / 远程控制协议方案后，改为**服务端云调用**：用户在龙虾群发消息后，Cloudflare Worker 通过 OpenAI 兼容 API 让内置成员 **「云 Codex」** 自动回复，无需安装 OpenClaw 或本地 CLI。

## 行为说明

- 默认群 `claw-g1` 增加成员 `cloud-codex`（⌨️ 图标，与 🦞 本地龙虾区分）
- **默认仅在被 @云 Codex 时回复**（`cloud_reply_mode = mention`），避免每条用户消息都消耗 token
- @ 提及仍绕过 `max_rounds` 限制，与现有 poll 逻辑一致
- 用户发消息 → `POST /api/claw/send` → `waitUntil(triggerCloudClawReplies)` → 写入 `claw_messages`

## 部署配置

在 Cloudflare Pages 环境变量中增加：

- `OPENAI_API_KEY`（必填）
- `CLOUD_CLAW_ENABLED`（可选，设为 `0` 关闭）

并执行 D1 迁移：`migrations/0018_add_cloud_claw_members.sql`

## 主要改动

- `functions/utils/cloudClawReply.ts` — 云端回复编排
- `functions/utils/clawReplyDecision.ts` — 与 poll 一致的 shouldReply 决策
- `functions/api/claw/send.ts` — 发消息后异步触发
- `src/config/aiCharacters.ts` — 增加 `gpt-4o-mini` / `OPENAI_API_KEY`
- `ClawChatUI` — 云端成员显示 ⌨️
- 文档：`README.md`、`docs/how2work.md` 新增「云端龙虾」章节

## 测试

- `node --test functions/utils/clawReplyDecision.test.mjs`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85651108-1ba4-473a-b76c-d6a2682d1d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85651108-1ba4-473a-b76c-d6a2682d1d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

